### PR TITLE
Modified path to find Plex package

### DIFF
--- a/updates/openflixr/updateplex.sh
+++ b/updates/openflixr/updateplex.sh
@@ -14,5 +14,5 @@ THISUSER=$(whoami)
 
 cd /opt/plexupdate
 bash plexupdate.sh -p 2> /dev/null
-dpkg -i plexmediaserver*.deb 2> /dev/null
-rm plexmediaserver* 2> /dev/null
+dpkg -i /tmp/plexmediaserver*.deb 2> /dev/null
+rm /tmp/plexmediaserver* 2> /dev/null


### PR DESCRIPTION
The plexupdate.sh script by default downloads the Plex debian package to the /tmp directory. The script, piping its output into null, is unable to alert the user that it's not actually updating Plex at all. While this solution is valid, modifying line 16 to go to the current directory would also be valid:

`bash plexupdate.sh --dldir ./ -p 2> /dev/null`

This issue was discovered after a fresh install followed by a full system update. After these were performed, Plex was unable to be found anywhere on the system, so it might not have been installed to begin with. Running the updateplex.sh script manually installed Plex correctly and allowed manual setup to continue.